### PR TITLE
Notification policy form UX improvements

### DIFF
--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/dispatch_config_summary.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/dispatch_config_summary.test.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { GroupingMode, ThrottleStrategy } from '@kbn/alerting-v2-schemas';
+import { DispatchConfigSummary } from './dispatch_config_summary';
+
+const renderSummary = (overrides: {
+  groupingMode?: GroupingMode;
+  groupBy?: string[];
+  throttleStrategy?: ThrottleStrategy;
+  throttleInterval?: string;
+}) =>
+  render(
+    <DispatchConfigSummary
+      groupingMode={overrides.groupingMode ?? 'per_episode'}
+      groupBy={overrides.groupBy ?? []}
+      throttleStrategy={overrides.throttleStrategy ?? 'on_status_change'}
+      throttleInterval={overrides.throttleInterval ?? ''}
+    />
+  );
+
+describe('DispatchConfigSummary', () => {
+  it('renders the title', () => {
+    renderSummary({});
+
+    expect(screen.getByText('Dispatch configuration')).toBeDefined();
+  });
+
+  describe('per_episode mode', () => {
+    it('shows status change summary', () => {
+      renderSummary({ groupingMode: 'per_episode', throttleStrategy: 'on_status_change' });
+
+      expect(
+        screen.getByText('Each episode is dispatched once per status transition.')
+      ).toBeDefined();
+    });
+
+    it('shows status change + repeat summary with interval', () => {
+      renderSummary({
+        groupingMode: 'per_episode',
+        throttleStrategy: 'per_status_interval',
+        throttleInterval: '5m',
+      });
+
+      expect(
+        screen.getByText(
+          'Each episode is dispatched on status change and repeated every 5 minute(s).'
+        )
+      ).toBeDefined();
+    });
+
+    it('shows status change + repeat summary without interval when empty', () => {
+      renderSummary({
+        groupingMode: 'per_episode',
+        throttleStrategy: 'per_status_interval',
+        throttleInterval: '',
+      });
+
+      expect(
+        screen.getByText('Each episode is dispatched on status change.')
+      ).toBeDefined();
+    });
+
+    it('shows every evaluation summary', () => {
+      renderSummary({ groupingMode: 'per_episode', throttleStrategy: 'every_time' });
+
+      expect(
+        screen.getByText(
+          'Each episode is dispatched on every evaluation with no throttle.'
+        )
+      ).toBeDefined();
+    });
+  });
+
+  describe('per_field (group) mode', () => {
+    it('shows prompt when no group-by fields are set', () => {
+      renderSummary({
+        groupingMode: 'per_field',
+        groupBy: [],
+        throttleStrategy: 'time_interval',
+      });
+
+      expect(
+        screen.getByText('Add group-by fields to configure grouped dispatch.')
+      ).toBeDefined();
+    });
+
+    it('shows throttle summary with fields', () => {
+      renderSummary({
+        groupingMode: 'per_field',
+        groupBy: ['host.name', 'service.name'],
+        throttleStrategy: 'time_interval',
+        throttleInterval: '10m',
+      });
+
+      expect(
+        screen.getByText(
+          'Episodes grouped by host.name, service.name are dispatched at most once every 10 minute(s).'
+        )
+      ).toBeDefined();
+    });
+
+    it('shows throttle summary without interval when empty', () => {
+      renderSummary({
+        groupingMode: 'per_field',
+        groupBy: ['host.name'],
+        throttleStrategy: 'time_interval',
+        throttleInterval: '',
+      });
+
+      expect(
+        screen.getByText('Episodes grouped by host.name are dispatched.')
+      ).toBeDefined();
+    });
+
+    it('shows every evaluation summary with fields', () => {
+      renderSummary({
+        groupingMode: 'per_field',
+        groupBy: ['host.name'],
+        throttleStrategy: 'every_time',
+      });
+
+      expect(
+        screen.getByText(
+          'Episodes grouped by host.name are dispatched on every evaluation with no throttle.'
+        )
+      ).toBeDefined();
+    });
+  });
+
+  describe('all (digest) mode', () => {
+    it('shows throttle summary', () => {
+      renderSummary({
+        groupingMode: 'all',
+        throttleStrategy: 'time_interval',
+        throttleInterval: '1h',
+      });
+
+      expect(
+        screen.getByText(
+          'All matched episodes are dispatched at most once every 1 hour(s).'
+        )
+      ).toBeDefined();
+    });
+
+    it('shows throttle summary without interval when empty', () => {
+      renderSummary({
+        groupingMode: 'all',
+        throttleStrategy: 'time_interval',
+        throttleInterval: '',
+      });
+
+      expect(
+        screen.getByText('All matched episodes are dispatched.')
+      ).toBeDefined();
+    });
+
+    it('shows every evaluation summary', () => {
+      renderSummary({ groupingMode: 'all', throttleStrategy: 'every_time' });
+
+      expect(
+        screen.getByText(
+          'All matched episodes are dispatched on every evaluation with no throttle.'
+        )
+      ).toBeDefined();
+    });
+  });
+
+  it('formats different duration units', () => {
+    renderSummary({
+      groupingMode: 'per_episode',
+      throttleStrategy: 'per_status_interval',
+      throttleInterval: '30s',
+    });
+
+    expect(
+      screen.getByText(
+        'Each episode is dispatched on status change and repeated every 30 second(s).'
+      )
+    ).toBeDefined();
+  });
+});

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/dispatch_config_summary.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/dispatch_config_summary.tsx
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiPanel, EuiSpacer, EuiText, EuiTitle } from '@elastic/eui';
+import type { GroupingMode, ThrottleStrategy } from '@kbn/alerting-v2-schemas';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+
+interface DispatchConfigSummaryProps {
+  groupingMode: GroupingMode;
+  groupBy: string[];
+  throttleStrategy: ThrottleStrategy;
+  throttleInterval: string;
+}
+
+const UNIT_LABELS: Record<string, string> = {
+  s: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatchSummary.unit.seconds', {
+    defaultMessage: 'second(s)',
+  }),
+  m: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatchSummary.unit.minutes', {
+    defaultMessage: 'minute(s)',
+  }),
+  h: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatchSummary.unit.hours', {
+    defaultMessage: 'hour(s)',
+  }),
+  d: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatchSummary.unit.days', {
+    defaultMessage: 'day(s)',
+  }),
+};
+
+const formatInterval = (raw: string): string => {
+  if (!raw) return '';
+  const unit = raw.charAt(raw.length - 1);
+  const value = parseInt(raw, 10);
+  if (Number.isNaN(value)) return raw;
+  return `${value} ${UNIT_LABELS[unit] ?? unit}`;
+};
+
+const getDispatchSummary = ({
+  groupingMode,
+  groupBy,
+  throttleStrategy,
+  throttleInterval,
+}: DispatchConfigSummaryProps): string => {
+  const interval = formatInterval(throttleInterval);
+  const fields = groupBy.join(', ');
+
+  if (groupingMode === 'per_episode') {
+    switch (throttleStrategy) {
+      case 'on_status_change':
+        return i18n.translate(
+          'xpack.alertingV2.notificationPolicy.form.dispatchSummary.episode.statusChange',
+          { defaultMessage: 'Each episode is dispatched once per status transition.' }
+        );
+      case 'per_status_interval':
+        if (!interval) {
+          return i18n.translate(
+            'xpack.alertingV2.notificationPolicy.form.dispatchSummary.episode.statusChangeNoInterval',
+            {
+              defaultMessage: 'Each episode is dispatched on status change.',
+            }
+          );
+        }
+        return i18n.translate(
+          'xpack.alertingV2.notificationPolicy.form.dispatchSummary.episode.statusChangeRepeat',
+          {
+            defaultMessage:
+              'Each episode is dispatched on status change and repeated every {interval}.',
+            values: { interval },
+          }
+        );
+      case 'every_time':
+        return i18n.translate(
+          'xpack.alertingV2.notificationPolicy.form.dispatchSummary.episode.everyEvaluation',
+          {
+            defaultMessage: 'Each episode is dispatched on every evaluation with no throttle.',
+          }
+        );
+    }
+  }
+
+  if (groupingMode === 'per_field') {
+    if (groupBy.length === 0) {
+      return i18n.translate(
+        'xpack.alertingV2.notificationPolicy.form.dispatchSummary.group.noFields',
+        { defaultMessage: 'Add group-by fields to configure grouped dispatch.' }
+      );
+    }
+
+    switch (throttleStrategy) {
+      case 'time_interval':
+        if (!interval) {
+          return i18n.translate(
+            'xpack.alertingV2.notificationPolicy.form.dispatchSummary.group.throttleNoInterval',
+            {
+              defaultMessage: 'Episodes grouped by {fields} are dispatched.',
+              values: { fields },
+            }
+          );
+        }
+        return i18n.translate(
+          'xpack.alertingV2.notificationPolicy.form.dispatchSummary.group.throttle',
+          {
+            defaultMessage:
+              'Episodes grouped by {fields} are dispatched at most once every {interval}.',
+            values: { fields, interval },
+          }
+        );
+      case 'every_time':
+        return i18n.translate(
+          'xpack.alertingV2.notificationPolicy.form.dispatchSummary.group.everyEvaluation',
+          {
+            defaultMessage:
+              'Episodes grouped by {fields} are dispatched on every evaluation with no throttle.',
+            values: { fields },
+          }
+        );
+    }
+  }
+
+  if (groupingMode === 'all') {
+    switch (throttleStrategy) {
+      case 'time_interval':
+        if (!interval) {
+          return i18n.translate(
+            'xpack.alertingV2.notificationPolicy.form.dispatchSummary.digest.throttleNoInterval',
+            { defaultMessage: 'All matched episodes are dispatched.' }
+          );
+        }
+        return i18n.translate(
+          'xpack.alertingV2.notificationPolicy.form.dispatchSummary.digest.throttle',
+          {
+            defaultMessage: 'All matched episodes are dispatched at most once every {interval}.',
+            values: { interval },
+          }
+        );
+      case 'every_time':
+        return i18n.translate(
+          'xpack.alertingV2.notificationPolicy.form.dispatchSummary.digest.everyEvaluation',
+          {
+            defaultMessage:
+              'All matched episodes are dispatched on every evaluation with no throttle.',
+          }
+        );
+    }
+  }
+
+  return '';
+};
+
+export const DispatchConfigSummary: React.FC<DispatchConfigSummaryProps> = (props) => {
+  const summary = getDispatchSummary(props);
+
+  if (!summary) return null;
+
+  return (
+    <EuiPanel
+      color="subdued"
+      paddingSize="m"
+      hasBorder={false}
+      data-test-subj="dispatchConfigCallout"
+    >
+      <EuiTitle size="xxs">
+        <h4>
+          {i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatchSummary.title', {
+            defaultMessage: 'Dispatch configuration',
+          })}
+        </h4>
+      </EuiTitle>
+      <EuiSpacer size="xs" />
+      <EuiText size="s" color="subdued" data-test-subj="dispatchConfigSummaryText">
+        {summary}
+      </EuiText>
+    </EuiPanel>
+  );
+};

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/dispatch_section.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/dispatch_section.tsx
@@ -12,13 +12,14 @@ import React, { useEffect, useMemo } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useFetchDataFields } from '../../../../hooks/use_fetch_data_fields';
 import {
+  AGGREGATE_STRATEGY_HELP_TEXT,
   AGGREGATE_STRATEGY_OPTIONS,
   DEFAULT_STRATEGY_FOR_MODE,
   DEFAULT_THROTTLE_INTERVAL,
   GROUPING_MODE_HELP_TEXT,
   GROUPING_MODE_OPTIONS,
+  PER_EPISODE_STRATEGY_HELP_TEXT,
   PER_EPISODE_STRATEGY_OPTIONS,
-  STRATEGY_HELP_TEXT,
   THROTTLE_INTERVAL_PATTERN,
 } from '../constants';
 import { needsInterval } from '../form_utils';
@@ -46,6 +47,8 @@ export const DispatchSection: React.FC = () => {
 
   const strategyOptions =
     groupingMode === 'per_episode' ? PER_EPISODE_STRATEGY_OPTIONS : AGGREGATE_STRATEGY_OPTIONS;
+  const strategyHelpText =
+    groupingMode === 'per_episode' ? PER_EPISODE_STRATEGY_HELP_TEXT : AGGREGATE_STRATEGY_HELP_TEXT;
 
   return (
     <>
@@ -53,11 +56,18 @@ export const DispatchSection: React.FC = () => {
         name="groupingMode"
         control={control}
         render={({ field }) => (
-          <EuiFormRow fullWidth helpText={GROUPING_MODE_HELP_TEXT[field.value]}>
+          <EuiFormRow
+            label={i18n.translate(
+              'xpack.alertingV2.notificationPolicy.form.dispatch.dispatchPer',
+              { defaultMessage: 'Dispatch per' }
+            )}
+            fullWidth
+            helpText={GROUPING_MODE_HELP_TEXT[field.value]}
+          >
             <EuiButtonGroup
               legend={i18n.translate(
                 'xpack.alertingV2.notificationPolicy.form.dispatch.modeLegend',
-                { defaultMessage: 'Dispatch mode' }
+                { defaultMessage: 'Dispatch per' }
               )}
               options={GROUPING_MODE_OPTIONS}
               idSelected={field.value}
@@ -104,7 +114,7 @@ export const DispatchSection: React.FC = () => {
                 'xpack.alertingV2.notificationPolicy.form.groupBy.helpText',
                 {
                   defaultMessage:
-                    'Episodes that share these field values are notified as one group.',
+                    'Episodes that share these field values are grouped together for dispatch.',
                 }
               )}
             >
@@ -114,7 +124,7 @@ export const DispatchSection: React.FC = () => {
                 data-test-subj="groupByInput"
                 placeholder={i18n.translate(
                   'xpack.alertingV2.notificationPolicy.form.groupBy.placeholder',
-                  { defaultMessage: 'Select or type a field name' }
+                  { defaultMessage: 'Add field…' }
                 )}
                 selectedOptions={field.value.map((g: string) => ({ label: g }))}
                 options={groupByOptions}
@@ -139,7 +149,7 @@ export const DispatchSection: React.FC = () => {
               defaultMessage: 'Frequency',
             })}
             fullWidth
-            helpText={STRATEGY_HELP_TEXT[throttleStrategy]}
+            helpText={strategyHelpText[throttleStrategy]}
           >
             <EuiSelect
               {...field}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/dispatch_section.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/dispatch_section.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiButtonGroup, EuiComboBox, EuiFormRow, EuiSelect } from '@elastic/eui';
+import { EuiButtonGroup, EuiComboBox, EuiFormRow, EuiSelect, EuiSpacer } from '@elastic/eui';
 import type { GroupingMode, ThrottleStrategy } from '@kbn/alerting-v2-schemas';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useMemo } from 'react';
@@ -24,12 +24,15 @@ import {
 } from '../constants';
 import { needsInterval } from '../form_utils';
 import type { NotificationPolicyFormState } from '../types';
+import { DispatchConfigSummary } from './dispatch_config_summary';
 import { DurationInput } from './duration_input/duration_input';
 
 export const DispatchSection: React.FC = () => {
   const { control, setValue, getValues } = useFormContext<NotificationPolicyFormState>();
   const groupingMode = useWatch({ control, name: 'groupingMode' });
+  const groupBy = useWatch({ control, name: 'groupBy' });
   const throttleStrategy = useWatch({ control, name: 'throttleStrategy' });
+  const throttleInterval = useWatch({ control, name: 'throttleInterval' });
   const { data: dataFieldNames } = useFetchDataFields();
 
   useEffect(() => {
@@ -57,10 +60,9 @@ export const DispatchSection: React.FC = () => {
         control={control}
         render={({ field }) => (
           <EuiFormRow
-            label={i18n.translate(
-              'xpack.alertingV2.notificationPolicy.form.dispatch.dispatchPer',
-              { defaultMessage: 'Dispatch per' }
-            )}
+            label={i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatch.dispatchPer', {
+              defaultMessage: 'Dispatch per',
+            })}
             fullWidth
             helpText={GROUPING_MODE_HELP_TEXT[field.value]}
           >
@@ -204,6 +206,14 @@ export const DispatchSection: React.FC = () => {
           )}
         />
       )}
+
+      <EuiSpacer size="m" />
+      <DispatchConfigSummary
+        groupingMode={groupingMode}
+        groupBy={groupBy}
+        throttleStrategy={throttleStrategy}
+        throttleInterval={throttleInterval}
+      />
     </>
   );
 };

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/duration_input/duration_input.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/duration_input/duration_input.tsx
@@ -52,6 +52,8 @@ const parseDuration = (raw: string): { value: number | ''; unit: DurationUnit } 
   return { value: Number.isNaN(parsed) ? '' : parsed, unit };
 };
 
+const DEFAULT_DURATION = '5m';
+
 interface DurationInputProps {
   value: string;
   onChange: (value: string) => void;
@@ -91,6 +93,15 @@ export function DurationInput({
     }
   };
 
+  const handleBlur = () => {
+    if (!value || durationValue === '') {
+      const parsed = parseDuration(DEFAULT_DURATION);
+      setDurationValue(parsed.value);
+      setDurationUnit(parsed.unit);
+      onChange(DEFAULT_DURATION);
+    }
+  };
+
   const handleUnitChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newUnit = e.target.value as DurationUnit;
     setDurationUnit(newUnit);
@@ -120,6 +131,7 @@ export function DurationInput({
       min={1}
       value={durationValue}
       onChange={handleValueChange}
+      onBlur={handleBlur}
       fullWidth
       isInvalid={isInvalid}
       data-test-subj={dataTestSubj ?? 'durationValueInput'}

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/workflow_selector.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/workflow_selector.tsx
@@ -72,7 +72,7 @@ export const WorkflowSelector = () => {
       >
         <FormattedMessage
           id="xpack.alertingV2.notificationPolicy.form.destination.workflowsDisabled.description"
-          defaultMessage="Enable the {settingName} setting in {advancedSettingsLink} to use workflows as destinations."
+          defaultMessage="Notification policies use Workflows for destinations, you'll need to enable them first. Enable the {settingName} setting in {advancedSettingsLink}, then refresh this page."
           values={{
             settingName: WORKFLOWS_UI_SETTING_ID,
             advancedSettingsLink: (

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/workflow_selector.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/components/workflow_selector.tsx
@@ -5,8 +5,12 @@
  * 2.0.
  */
 
-import { EuiComboBox, EuiFormRow } from '@elastic/eui';
+import { EuiCallOut, EuiComboBox, EuiFormRow, EuiLink } from '@elastic/eui';
+import { CoreStart, useService } from '@kbn/core-di-browser';
+import { WORKFLOWS_APP_ID } from '@kbn/deeplinks-workflows';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { WORKFLOWS_UI_SETTING_ID } from '@kbn/workflows';
 import React, { useEffect, useState } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useDebouncedValue } from '@kbn/react-hooks';
@@ -21,12 +25,18 @@ interface SelectedWorkflow {
 export const WorkflowSelector = () => {
   const { control } = useFormContext<NotificationPolicyFormState>();
   const destinations = useWatch({ control, name: 'destinations' });
+  const application = useService(CoreStart('application'));
+  const uiSettings = useService(CoreStart('uiSettings'));
+  const isWorkflowsEnabled = uiSettings.get<boolean>(WORKFLOWS_UI_SETTING_ID);
 
   const [selectedWorkflows, setSelectedWorkflows] = useState<SelectedWorkflow[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedQuery = useDebouncedValue(searchQuery, 300);
 
-  const { data: workflowsData, isLoading } = useFetchWorkflows({ query: debouncedQuery });
+  const { data: workflowsData, isLoading } = useFetchWorkflows({
+    query: debouncedQuery,
+    isEnabled: isWorkflowsEnabled,
+  });
 
   useEffect(() => {
     if (selectedWorkflows.length > 0 || destinations.length === 0 || !workflowsData) {
@@ -44,6 +54,43 @@ export const WorkflowSelector = () => {
     value: w.id,
   }));
 
+  if (!isWorkflowsEnabled) {
+    const settingsUrl = application.getUrlForApp('management', {
+      path: `/kibana/settings?query=${encodeURIComponent(WORKFLOWS_UI_SETTING_ID)}`,
+    });
+
+    return (
+      <EuiCallOut
+        announceOnMount={false}
+        title={i18n.translate(
+          'xpack.alertingV2.notificationPolicy.form.destination.workflowsDisabled.title',
+          { defaultMessage: 'Workflows are not enabled' }
+        )}
+        color="warning"
+        iconType="warning"
+        data-test-subj="workflowsDisabledCallout"
+      >
+        <FormattedMessage
+          id="xpack.alertingV2.notificationPolicy.form.destination.workflowsDisabled.description"
+          defaultMessage="Enable the {settingName} setting in {advancedSettingsLink} to use workflows as destinations."
+          values={{
+            settingName: WORKFLOWS_UI_SETTING_ID,
+            advancedSettingsLink: (
+              <EuiLink href={settingsUrl} data-test-subj="workflowsDisabledSettingsLink">
+                <FormattedMessage
+                  id="xpack.alertingV2.notificationPolicy.form.destination.workflowsDisabled.advancedSettingsLink"
+                  defaultMessage="Advanced Settings"
+                />
+              </EuiLink>
+            ),
+          }}
+        />
+      </EuiCallOut>
+    );
+  }
+
+  const createWorkflowUrl = application.getUrlForApp(WORKFLOWS_APP_ID, { path: '/create' });
+
   return (
     <Controller
       name="destinations"
@@ -58,12 +105,25 @@ export const WorkflowSelector = () => {
       }}
       render={({ field, fieldState: { error } }) => (
         <EuiFormRow
-          label={i18n.translate('xpack.alertingV2.notificationPolicy.form.destination', {
-            defaultMessage: 'Destinations',
+          label={i18n.translate('xpack.alertingV2.notificationPolicy.form.destination.workflows', {
+            defaultMessage: 'Workflows',
           })}
           fullWidth
           isInvalid={!!error}
           error={error?.message}
+          helpText={
+            <EuiLink
+              href={createWorkflowUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-test-subj="createWorkflowLink"
+            >
+              {i18n.translate(
+                'xpack.alertingV2.notificationPolicy.form.destination.createWorkflow',
+                { defaultMessage: 'Create a workflow' }
+              )}
+            </EuiLink>
+          }
         >
           <EuiComboBox
             fullWidth

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/constants.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/constants.ts
@@ -13,13 +13,13 @@ export const GROUPING_MODE_OPTIONS: Array<{ id: GroupingMode; label: string }> =
   {
     id: 'per_episode',
     label: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatch.mode.perEpisode', {
-      defaultMessage: 'Per episode',
+      defaultMessage: 'Episode',
     }),
   },
   {
     id: 'per_field',
     label: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatch.mode.perGroup', {
-      defaultMessage: 'Per group',
+      defaultMessage: 'Group',
     }),
   },
   {
@@ -33,7 +33,7 @@ export const GROUPING_MODE_OPTIONS: Array<{ id: GroupingMode; label: string }> =
 export const GROUPING_MODE_HELP_TEXT: Record<GroupingMode, string> = {
   per_episode: i18n.translate(
     'xpack.alertingV2.notificationPolicy.form.dispatch.mode.perEpisode.help',
-    { defaultMessage: 'One dispatch for each matched episode.' }
+    { defaultMessage: 'One dispatch per matched episode.' }
   ),
   per_field: i18n.translate(
     'xpack.alertingV2.notificationPolicy.form.dispatch.mode.perGroup.help',
@@ -57,13 +57,13 @@ export const PER_EPISODE_STRATEGY_OPTIONS: Array<{ value: ThrottleStrategy; text
     value: 'per_status_interval',
     text: i18n.translate(
       'xpack.alertingV2.notificationPolicy.form.dispatch.strategy.perStatusInterval',
-      { defaultMessage: 'On status change + repeat on interval' }
+      { defaultMessage: 'On status change + repeat at interval' }
     ),
   },
   {
     value: 'every_time',
     text: i18n.translate('xpack.alertingV2.notificationPolicy.form.dispatch.strategy.everyTime', {
-      defaultMessage: 'Every evaluation (no throttle)',
+      defaultMessage: 'Every evaluation (per episode, no throttle)',
     }),
   },
 ];
@@ -73,14 +73,14 @@ export const AGGREGATE_STRATEGY_OPTIONS: Array<{ value: ThrottleStrategy; text: 
     value: 'time_interval',
     text: i18n.translate(
       'xpack.alertingV2.notificationPolicy.form.dispatch.strategy.timeInterval',
-      { defaultMessage: 'At most once every...' }
+      { defaultMessage: 'At most once every…' }
     ),
   },
   {
     value: 'every_time',
     text: i18n.translate(
       'xpack.alertingV2.notificationPolicy.form.dispatch.strategy.everyTimeAggregate',
-      { defaultMessage: 'Every evaluation (no throttle)' }
+      { defaultMessage: 'Every evaluation (per group, no throttle)' }
     ),
   },
 ];
@@ -91,7 +91,7 @@ export const DEFAULT_STRATEGY_FOR_MODE: Record<GroupingMode, ThrottleStrategy> =
   all: 'time_interval',
 };
 
-export const STRATEGY_HELP_TEXT: Partial<Record<ThrottleStrategy, string>> = {
+export const PER_EPISODE_STRATEGY_HELP_TEXT: Partial<Record<ThrottleStrategy, string>> = {
   on_status_change: i18n.translate(
     'xpack.alertingV2.notificationPolicy.form.dispatch.strategy.onStatusChange.help',
     { defaultMessage: 'When the episode status changes.' }
@@ -103,6 +103,17 @@ export const STRATEGY_HELP_TEXT: Partial<Record<ThrottleStrategy, string>> = {
   every_time: i18n.translate(
     'xpack.alertingV2.notificationPolicy.form.dispatch.strategy.everyTime.help',
     { defaultMessage: 'No minimum time between dispatches for the same episode.' }
+  ),
+};
+
+export const AGGREGATE_STRATEGY_HELP_TEXT: Partial<Record<ThrottleStrategy, string>> = {
+  time_interval: i18n.translate(
+    'xpack.alertingV2.notificationPolicy.form.dispatch.strategy.timeInterval.help',
+    { defaultMessage: 'At most one dispatch per group per repeat interval.' }
+  ),
+  every_time: i18n.translate(
+    'xpack.alertingV2.notificationPolicy.form.dispatch.strategy.everyTimeAggregate.help',
+    { defaultMessage: 'No minimum time between dispatches for the same group.' }
   ),
 };
 

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.test.tsx
@@ -15,6 +15,24 @@ import { DEFAULT_FORM_STATE } from './constants';
 import { NotificationPolicyForm } from './notification_policy_form';
 import type { NotificationPolicyFormState } from './types';
 
+const mockGetUrlForApp = jest.fn(
+  (appId: string, { path }: { path: string }) => `/app/${appId}${path}`
+);
+let mockWorkflowsEnabled = true;
+
+jest.mock('@kbn/core-di-browser', () => ({
+  useService: (token: unknown) => {
+    if (token === 'application') {
+      return { getUrlForApp: mockGetUrlForApp };
+    }
+    if (token === 'uiSettings') {
+      return { get: () => mockWorkflowsEnabled };
+    }
+    return {};
+  },
+  CoreStart: (key: string) => key,
+}));
+
 jest.mock('./components/matcher_input', () => ({
   MatcherInput: (props: {
     value: string;
@@ -68,6 +86,11 @@ const TEST_SUBJ = {
 } as const;
 
 describe('NotificationPolicyForm', () => {
+  beforeEach(() => {
+    mockWorkflowsEnabled = true;
+    jest.clearAllMocks();
+  });
+
   it('shows required errors for name on blur', async () => {
     const user = userEvent.setup();
     renderForm();
@@ -198,5 +221,26 @@ describe('NotificationPolicyForm', () => {
     });
 
     expect(screen.getByTestId(TEST_SUBJ.throttleIntervalInput)).toHaveValue(5);
+  });
+
+  it('renders create workflow link when workflows are enabled', () => {
+    renderForm();
+
+    expect(screen.getByTestId('createWorkflowLink')).toBeInTheDocument();
+    expect(screen.getByTestId('createWorkflowLink')).toHaveAttribute(
+      'href',
+      '/app/workflows/create'
+    );
+    expect(screen.getByTestId('createWorkflowLink')).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders warning callout when workflows are disabled', () => {
+    mockWorkflowsEnabled = false;
+    renderForm();
+
+    expect(screen.getByTestId('workflowsDisabledCallout')).toBeInTheDocument();
+    expect(screen.getByText('Workflows are not enabled')).toBeInTheDocument();
+    expect(screen.getByTestId('workflowsDisabledSettingsLink')).toBeInTheDocument();
+    expect(screen.queryByTestId('destinationsInput')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.tsx
@@ -192,7 +192,7 @@ export const NotificationPolicyForm = () => {
           <EuiText size="xs" color="subdued">
             <FormattedMessage
               id="xpack.alertingV2.notificationPolicy.form.destination.description"
-              defaultMessage="Where should dispatches be sent."
+              defaultMessage="Select the workflows that should be triggered when dispatches are sent."
             />
           </EuiText>
         </EuiSplitPanel.Inner>

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form/notification_policy_form.tsx
@@ -24,6 +24,14 @@ import { WorkflowSelector } from './components/workflow_selector';
 import type { NotificationPolicyFormState } from './types';
 import { useFetchDataFields } from '../../../hooks/use_fetch_data_fields';
 
+const optionalLabel = (
+  <EuiText color="subdued" size="xs">
+    {i18n.translate('xpack.alertingV2.notificationPolicy.form.optionalLabel', {
+      defaultMessage: 'Optional',
+    })}
+  </EuiText>
+);
+
 export const NotificationPolicyForm = () => {
   const { control } = useFormContext<NotificationPolicyFormState>();
   const { data: dataFieldNames } = useFetchDataFields();
@@ -87,6 +95,7 @@ export const NotificationPolicyForm = () => {
                 label={i18n.translate('xpack.alertingV2.notificationPolicy.form.description', {
                   defaultMessage: 'Description',
                 })}
+                labelAppend={optionalLabel}
                 fullWidth
               >
                 <EuiTextArea
@@ -134,6 +143,7 @@ export const NotificationPolicyForm = () => {
                 label={i18n.translate('xpack.alertingV2.notificationPolicy.form.matcher', {
                   defaultMessage: 'Matcher',
                 })}
+                labelAppend={optionalLabel}
                 fullWidth
               >
                 <MatcherInput

--- a/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form_flyout/notification_policy_form_flyout.test.tsx
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/form_flyout/notification_policy_form_flyout.test.tsx
@@ -12,6 +12,21 @@ import type { NotificationPolicyResponse } from '@kbn/alerting-v2-schemas';
 import { I18nProvider } from '@kbn/i18n-react';
 import { NotificationPolicyFormFlyout } from './notification_policy_form_flyout';
 
+jest.mock('@kbn/core-di-browser', () => ({
+  useService: (token: unknown) => {
+    if (token === 'application') {
+      return {
+        getUrlForApp: (appId: string, { path }: { path: string }) => `/app/${appId}${path}`,
+      };
+    }
+    if (token === 'uiSettings') {
+      return { get: () => true };
+    }
+    return {};
+  },
+  CoreStart: (key: string) => key,
+}));
+
 jest.mock('../form/components/matcher_input', () => ({
   MatcherInput: (props: {
     value: string;

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/__storybook_mocks__/use_fetch_workflows.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/__storybook_mocks__/use_fetch_workflows.ts
@@ -46,5 +46,5 @@ const MOCK_WORKFLOWS: WorkflowListDto = {
   ],
 };
 
-export const useFetchWorkflows = () =>
+export const useFetchWorkflows = (_params?: { query: string; isEnabled?: boolean }) =>
   ({ data: MOCK_WORKFLOWS, isLoading: false } as UseQueryResult<WorkflowListDto, Error>);

--- a/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_workflows.ts
+++ b/x-pack/platform/plugins/shared/alerting_v2/public/hooks/use_fetch_workflows.ts
@@ -14,15 +14,17 @@ import { workflowKeys } from './query_key_factory';
 
 interface UseFetchWorkflowsParams {
   query: string;
+  isEnabled?: boolean;
 }
 
-export const useFetchWorkflows = ({ query }: UseFetchWorkflowsParams) => {
+export const useFetchWorkflows = ({ query, isEnabled = true }: UseFetchWorkflowsParams) => {
   const workflowsApi = useService(WorkflowsApi);
   const { toasts } = useService(CoreStart('notifications'));
 
   return useQuery<WorkflowListDto, Error>({
     queryKey: workflowKeys.search({ query }),
     queryFn: () => workflowsApi.searchWorkflows({ query, size: 100, page: 1 }),
+    enabled: isEnabled,
     refetchOnWindowFocus: false,
     keepPreviousData: true,
     onError: (error: Error) => {


### PR DESCRIPTION
## Summary

Addresses multiple M1 Audit UX issues for the notification policy create/edit form:

- **Workflow selector: handle disabled state** — When `workflows:ui:enabled` is `false`, show a warning callout instead of making failing API calls (elastic/rna-program#282)
- **Workflow selector: create workflow link** — Add a "Create a workflow" link below the selector that opens in a new tab (elastic/rna-program#279)
- **Rename destinations field** — Rename field label from "Destinations" to "Workflows" and update section description (elastic/rna-program#283)
- **Optional labels** — Add "Optional" label to Description and Matcher fields (elastic/rna-program#287)
- **Dispatch section labels** — Update all dispatch section labels and help texts to match design (elastic/rna-program#285)
- **Dispatch configuration summary** — Add a dynamic summary panel below dispatch fields that describes the effective dispatch configuration in plain language (elastic/rna-program#289)
- **Duration input default on blur** — Reset duration input to 5m when the field is left empty

Resolves elastic/rna-program#279
Resolves elastic/rna-program#282
Resolves elastic/rna-program#283
Resolves elastic/rna-program#285
Resolves elastic/rna-program#287
Resolves elastic/rna-program#289

## Test plan

- [ ] Set `workflows:ui:enabled` to `false` → verify warning callout, no error toasts
- [ ] Set `workflows:ui:enabled` to `true` → verify selector with "Create a workflow" link opening in new tab
- [ ] Verify "Optional" label on Description and Matcher fields
- [ ] Verify dispatch section labels match design (Episode/Group, Dispatch per, updated frequency labels)
- [ ] Verify dispatch configuration summary updates dynamically as options change
- [ ] Verify duration input resets to 5m on blur when empty
- [ ] Run `node scripts/jest x-pack/platform/plugins/shared/alerting_v2/public/components/notification_policy/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)